### PR TITLE
feat: Add reset button with confirmation modal

### DIFF
--- a/src/components/ResetConfirmationModal.js
+++ b/src/components/ResetConfirmationModal.js
@@ -1,0 +1,49 @@
+import React from 'react';
+
+/**
+ * Modal component to confirm application reset.
+ * @param {object} props - Component props
+ * @param {function} props.onConfirm - Function to call when reset is confirmed.
+ * @param {function} props.onCancel - Function to call when reset is cancelled.
+ */
+function ResetConfirmationModal({ onConfirm, onCancel }) {
+  // Placeholder functions for now
+  const handleConfirm = () => {
+    console.log('Reset confirmed');
+    onConfirm();
+  };
+
+  const handleCancel = () => {
+    console.log('Reset cancelled');
+    onCancel();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-center">
+      <div className="relative p-8 bg-white dark:bg-gray-800 w-full max-w-md m-auto flex-col flex rounded-lg shadow-lg">
+        <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
+          Confirm Reset
+        </h2>
+        <p className="text-sm text-gray-700 dark:text-gray-300 mb-6">
+          Are you sure you want to reset all application data? This action cannot be undone.
+        </p>
+        <div className="flex justify-end space-x-4">
+          <button
+            onClick={handleCancel}
+            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-900"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 dark:focus:ring-offset-gray-900"
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ResetConfirmationModal;

--- a/src/layout/Header.js
+++ b/src/layout/Header.js
@@ -1,17 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useUserPreferences } from '../contexts/UserPreferencesContext';
-import { SunIcon, MoonIcon } from '@heroicons/react/24/outline'; // Using Heroicons for a more polished look
+import { SunIcon, MoonIcon, ArrowPathIcon } from '@heroicons/react/24/outline'; // Using Heroicons for a more polished look
+import ResetConfirmationModal from '../components/ResetConfirmationModal'; // Import the modal
 
 /**
- * Application header component with dark mode toggle
+ * Application header component with dark mode toggle and reset button
  */
 function Header() {
   const { darkMode, toggleDarkMode } = useUserPreferences();
+  const [isModalOpen, setIsModalOpen] = useState(false); // State for modal visibility
+
+  const handleResetClick = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleConfirmReset = () => {
+    console.log('Reset confirmed in Header. Clearing localStorage and reloading...');
+    localStorage.clear(); // Clear all data from localStorage
+    window.location.reload(); // Reload the application
+    setIsModalOpen(false); // Close the modal (though page reload might make this redundant)
+  };
+
+  const handleCancelReset = () => {
+    setIsModalOpen(false);
+  };
   
   return (
-    <header className="fixed top-6 right-6 z-50">
-      <button
-        onClick={toggleDarkMode}
+    <>
+      <header className="fixed top-6 right-6 z-50 flex items-center"> {/* Ensure buttons are in a flex container if needed */}
+        <button
+          onClick={toggleDarkMode}
         className="icon-button rounded-full p-2.5 hover:rotate-12 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-transparent focus:ring-indigo-500 dark:focus:ring-offset-gray-900 transition-all duration-300 ease-in-out shadow-lg hover:shadow-xl"
         aria-label="Toggle dark mode"
       >
@@ -21,7 +39,21 @@ function Header() {
           <MoonIcon className="h-6 w-6 text-indigo-300" />
         )}
       </button>
-    </header>
+        <button
+          onClick={handleResetClick} // Updated onClick handler
+          className="ml-2 icon-button rounded-full p-2.5 hover:rotate-12 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-transparent focus:ring-indigo-500 dark:focus:ring-offset-gray-900 transition-all duration-300 ease-in-out shadow-lg hover:shadow-xl"
+          aria-label="Reset application"
+        >
+          <ArrowPathIcon className="h-6 w-6 text-red-500 dark:text-red-400" />
+        </button>
+      </header>
+      {isModalOpen && (
+        <ResetConfirmationModal
+          onConfirm={handleConfirmReset}
+          onCancel={handleCancelReset}
+        />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
This commit introduces a reset button in the application header, next to the dark mode toggle.

Key changes:
- Added a new reset button to `src/layout/Header.js`.
- Created `src/components/ResetConfirmationModal.js` to prompt you for confirmation before resetting.
- Integrated the modal with the header, managing its visibility via state.
- Implemented the reset functionality:
    - Clicking "Confirm" in the modal clears all data from `localStorage`.
    - The application then reloads (`window.location.reload()`) to reflect the cleared state.
- Styled the new button (with a distinct red icon) and modal for consistency and clarity in both light and dark modes.

This feature allows you to easily clear your local application data and start fresh.