### PR TITLE
Fix deck completion time tracking

### DIFF
--- a/src/App.backButton.test.js
+++ b/src/App.backButton.test.js
@@ -87,6 +87,7 @@ describe('Back Button Visibility on Completion Page', () => {
       isDeckStudyMode: false, // Not in deck study mode
       deckStudyComplete: false, // Deck study was NOT completed
       studyDeckId: null,
+      studyCardIds: [],
       deckCompletionTimes: [],
       createCard: jest.fn(),
       updateCard: jest.fn(),
@@ -124,6 +125,7 @@ describe('Back Button Visibility on Completion Page', () => {
       isDeckStudyMode: false, // Not in deck study mode
       deckStudyComplete: false, // Deck study was NOT completed
       studyDeckId: null,
+      studyCardIds: [],
       deckCompletionTimes: [],
       createCard: jest.fn(),
       updateCard: jest.fn(),
@@ -162,6 +164,7 @@ describe('Back Button Visibility on Completion Page', () => {
       isDeckStudyMode: true, // In deck study mode
       deckStudyComplete: false, // Deck study is ongoing
       studyDeckId: 'test-deck',
+      studyCardIds: [],
       deckCompletionTimes: [],
       createCard: jest.fn(),
       updateCard: jest.fn(),

--- a/src/App.dualModal.test.js
+++ b/src/App.dualModal.test.js
@@ -88,6 +88,7 @@ describe('Dual Modal Bug Fix', () => {
       isDeckStudyMode: false, // Deck study mode was exited
       deckStudyComplete: true, // Deck study was completed
       studyDeckId: 'test-deck',
+      studyCardIds: [],
       deckCompletionTimes: [1000, 2000, 1500],
       createCard: jest.fn(),
       updateCard: jest.fn(),
@@ -126,6 +127,7 @@ describe('Dual Modal Bug Fix', () => {
       isDeckStudyMode: false, // Not in deck study mode
       deckStudyComplete: false, // Deck study was NOT completed
       studyDeckId: null,
+      studyCardIds: [],
       deckCompletionTimes: [],
       createCard: jest.fn(),
       updateCard: jest.fn(),
@@ -164,6 +166,7 @@ describe('Dual Modal Bug Fix', () => {
       isDeckStudyMode: false, // Not in deck study mode
       deckStudyComplete: false, // Deck study was NOT completed
       studyDeckId: null,
+      studyCardIds: [],
       deckCompletionTimes: [],
       createCard: jest.fn(),
       updateCard: jest.fn(),
@@ -202,6 +205,7 @@ describe('Dual Modal Bug Fix', () => {
       isDeckStudyMode: false, // Deck study mode was exited
       deckStudyComplete: true, // Deck study was completed
       studyDeckId: 'test-deck',
+      studyCardIds: [],
       deckCompletionTimes: [1000, 2000, 1500],
       createCard: jest.fn(),
       updateCard: jest.fn(),

--- a/src/App.js
+++ b/src/App.js
@@ -48,6 +48,7 @@ function AppContent() {
     isDeckStudyMode,
     deckStudyComplete,
     studyDeckId,
+    studyCardIds,
     deckCompletionTimes,
     exitDeckStudy
   } = useAppState();
@@ -176,7 +177,7 @@ function AppContent() {
             <DeckCompletionRoute
               completionTimes={deckCompletionTimes}
               deckTitle={decks.find(d => d.id === studyDeckId)?.title || 'Deck Study'}
-              cardCount={deckCompletionTimes.length}
+              cardCount={studyCardIds.length}
               onReturnToMenu={handleExitDeckStudy}
             />
           )}

--- a/src/features/deck-study/components/DeckStudyMode.js
+++ b/src/features/deck-study/components/DeckStudyMode.js
@@ -21,13 +21,14 @@ function DeckStudyMode({
   loadNextStudyCard,
   beginNextCard
 }) {
-  const { 
+  const {
     studyDeckId,
     studyCardIds,
     currentCardIndex,
     decks,
     nextStudyCard,
-    completeDeckStudy
+    completeDeckStudy,
+    setDeckCompletionTimes
   } = useAppState();
 
   // Get current deck and card
@@ -44,10 +45,21 @@ function DeckStudyMode({
       // Begin typing the next card
       beginNextCard();
     } else if (isComplete && currentCardIndex === studyCardIds.length - 1) {
-      // All cards completed
+      // Push final completion time and finish deck study
+      setDeckCompletionTimes(prev => [...prev, completionTime]);
       completeDeckStudy();
     }
-  }, [isComplete, currentCardIndex, studyCardIds.length, completionTime, nextStudyCard, completeDeckStudy, loadNextStudyCard, beginNextCard]);
+  }, [
+    isComplete,
+    currentCardIndex,
+    studyCardIds.length,
+    completionTime,
+    nextStudyCard,
+    completeDeckStudy,
+    loadNextStudyCard,
+    beginNextCard,
+    setDeckCompletionTimes
+  ]);
 
   return (
     <motion.div 


### PR DESCRIPTION
## Summary
- push last card time before ending deck study mode
- display total card count via study card IDs
- adjust tests for `studyCardIds`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f40bba38883339c90ca3e98f2eb89