### PR TITLE
Remove stray console logging

### DIFF
--- a/src/components/ReferenceTyping.js
+++ b/src/components/ReferenceTyping.js
@@ -127,14 +127,9 @@ export default function ReferenceTyping({
   } = useMemoryTyping({
     referenceText: selectedReference,
     easyMode: easyMode,
-    ghostTextEnabled: ghostTextEnabled
+  ghostTextEnabled: ghostTextEnabled
   });
-  
-  // For debugging
-  useEffect(() => {
-    console.log('Ghost text:', ghostText);
-    console.log('Last correct index:', lastCorrectIndex);
-  }, [ghostText, lastCorrectIndex]);
+
 
   // Automatically set isReferenceOpen if showReferenceEnabled is true
   useEffect(() => {

--- a/src/features/typing/components/ReferenceTyping.js
+++ b/src/features/typing/components/ReferenceTyping.js
@@ -88,11 +88,6 @@ export default function ReferenceTyping({
     }
   }, [typingStarted, timerRunning, setTimerRunning]);
   
-  // Debug logs
-  useEffect(() => {
-    console.log('Ghost text:', ghostText);
-    console.log('Last correct index:', lastCorrectIndex);
-  }, [ghostText, lastCorrectIndex]);
 
   // Automatically set isReferenceOpen if showReferenceEnabled is true
   useEffect(() => {

--- a/src/utils/memoryUtils.js
+++ b/src/utils/memoryUtils.js
@@ -124,11 +124,9 @@ export function loadCardsFromStorage(defaultCards) {
     const savedCards = localStorage.getItem('memoryCards');
     if (savedCards) {
       const parsedCards = JSON.parse(savedCards);
-      console.log('Loaded saved cards from localStorage:', parsedCards.length);
       return parsedCards;
     }
-    
-    console.log('No saved cards found, using default cards:', defaultCards.length);
+
     const defaultCardsWithTimestamps = defaultCards.map(card => ({
       ...card,
       createdAt: card.createdAt || Date.now()
@@ -291,11 +289,9 @@ export function loadDecksFromStorage(defaultDecks) {
     const savedDecks = localStorage.getItem('memoryDecks');
     if (savedDecks) {
       const parsedDecks = JSON.parse(savedDecks);
-      console.log('Loaded saved decks from localStorage:', parsedDecks.length);
       return parsedDecks;
     }
-    
-    console.log('No saved decks found, using default decks:', defaultDecks.length);
+
     const defaultDecksWithTimestamps = defaultDecks.map(deck => ({
       ...deck,
       createdAt: deck.createdAt || Date.now()


### PR DESCRIPTION
## Summary
- strip debugging logs from reference typing components
- remove leftover logging in memory utilities

## Testing
- `npm test -- --coverage --watchAll=false` *(fails: Test Suites: 2 failed, 19 passed, 21 total)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f563a54788333af7ce8c401f16232